### PR TITLE
fix(ci): publisher concurrency

### DIFF
--- a/.github/workflows/bin/publisher.py
+++ b/.github/workflows/bin/publisher.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import os
+import json
+import requests
+import subprocess
+
+
+def fetch_unhandled_issues():
+    r = requests.get(
+        f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/issues?labels=signature-approved&state=open",
+        headers={"Authorization": f'token {os.environ["GITHUB_TOKEN"]}'},
+    )
+    return r.json()
+
+
+def main():
+    issues = fetch_unhandled_issues()
+    env = os.environ.copy()
+    issues_to_close = []
+    for issue in issues:
+        env["ISSUE_AUTHOR_URL"] = issue["user"]["html_url"]
+        env["ISSUE_BODY"] = issue["body"] if issue["body"] else ""
+        subprocess.run(
+            ["python3", ".github/workflows/bin/sign_handler.py", "--commit-sign"],
+            env=env,
+        )
+        issues_to_close.append(issue["number"])
+
+    for issue in issues_to_close:
+        print(f"closes #{issue}", end=", ")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/bin/sign_handler.py
+++ b/.github/workflows/bin/sign_handler.py
@@ -66,4 +66,5 @@ def main():
         print(e)
         return
 
-main()
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sign_publisher.yml
+++ b/.github/workflows/sign_publisher.yml
@@ -2,7 +2,9 @@
 # Contributed by @developStorm on GitHub
 
 name: Signature Publisher
-# concurrency: new-sign-publishing
+concurrency: 
+  group: new-sign-publishing
+  cancel-in-progress: true
 on:
   issues:
     types:
@@ -12,23 +14,25 @@ jobs:
     if: github.event.label.name == 'signature-approved'
     runs-on: ubuntu-latest
     steps:
-      - name: Get Publish Lock
-        uses: shogo82148/actions-mutex@v1
-        with:
-          key: publish-new-signature
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Write New Signature
-        env:
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_AUTHOR_URL: ${{ github.event.issue.user.html_url }}
+      - name: Install dependencies
         run: |
-          python3 .github/workflows/bin/sign_handler.py --commit-sign
+          python3 -m pip install requests
+      - name: Write New Signature
+        id: publisher
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::set-output name=commit_body::$(python3 .github/workflows/bin/publisher.py)"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: 'New signature, closes #${{ github.event.issue.number }}'
+          commit_message: |
+            Add new signature(s)
+            
+            ${{ steps.publisher.outputs.commit_body }}'
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/sign_publisher.yml
+++ b/.github/workflows/sign_publisher.yml
@@ -32,7 +32,7 @@ jobs:
           commit_message: |
             Add new signature(s)
             
-            ${{ steps.publisher.outputs.commit_body }}'
+            ${{ steps.publisher.outputs.commit_body }}
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
I did some testing on my fork and it should solve the problem now.

(Tested by tagging 9 issues in the same time, the new approach handled them correctly: [commit](https://github.com/developStorm/appleprivacyletter/commit/185d502ccb9f4df9dbd2062a39f58183b5d2c6d0), [action run](https://github.com/developStorm/appleprivacyletter/runs/3269113312))

This new approach also increases robustness, so that even if the worst-case workflow run fails, any previously unprocessed issues will be reprocessed the next time any issue get labeled.