### PR TITLE
Further URL Clarification

### DIFF
--- a/.github/ISSUE_TEMPLATE/sign-letter.yml
+++ b/.github/ISSUE_TEMPLATE/sign-letter.yml
@@ -14,7 +14,7 @@ body:
      label: Affiliation
  - type: input
    attributes:
-     label: URL of your Website/Twitter/etc. (You MUST Prefix URL with http(s)://)
+     label: URL of your Website/Twitter/etc. You MUST Prefix URL with http(s)://
  - type: checkboxes
    attributes:
      options:

--- a/.github/ISSUE_TEMPLATE/sign-letter.yml
+++ b/.github/ISSUE_TEMPLATE/sign-letter.yml
@@ -14,7 +14,7 @@ body:
      label: Affiliation
  - type: input
    attributes:
-     label: URL of your Website/Twitter/etc.
+     label: URL of your Website/Twitter/etc. (You MUST Prefix URL with http(s)://)
  - type: checkboxes
    attributes:
      options:


### PR DESCRIPTION
Multiple PR regarding URL fixes.  Recommended addition to emphasize prefix of https:// or http:// to minimize URL fix PR.