### PR TITLE
Move Cryptomator to "Organizations" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
 				<li><a href="https://chaos-siegen.de">Chaos Computer Club Siegen e. V.</a></li>
 				<li><a href="https://onestla.tech">Collectif Onestla.tech</a></li>
 				<li><a href="https://collegroup.com">Collé Group, LLC</a></li>
+				<li><a href="https://cryptomator.org/">Cryptomator</a></li>
 				<li><a href="https://www.dotplex.com">dotplex Secure Hosting</a></li>
 				<li><a href="https://freedom.press">Freedom of the Press Foundation</a></li>
 				<li><a href="https://gigahost.uk">Gigahost</a></li>

--- a/res/js/signatures.js
+++ b/res/js/signatures.js
@@ -30384,11 +30384,6 @@ let individuals = [
 		"affil": "Individual",
 		"expert": false
 	}, {
-		"name": "Cryptomator",
-		"url": "https://github.com/SailReal",
-		"affil": "Individual",
-		"expert": false
-	}, {
 		"name": "Chaostreff Flensburg e.V.",
 		"url": "https://github.com/flemssound",
 		"affil": "Individual",


### PR DESCRIPTION
As just added in https://github.com/nadimkobeissi/appleprivacyletter/issues/6429, would be awesome to move Cryptomator from "Individuals" to the "Organizations" section.