### PR TITLE
Move Xeovo to organisation 

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
 				<li><a href="https://www.sym.bio">SymbioSystems LLC</a></li>
 				<li><a href="https://www.thinkprivacy.ch">ThinkPrivacy</a></li>
 				<li><a href="https://webtorrent.io">WebTorrent</a></li>
+				<li><a href="https://xeovo.com">Xeovo VPN</a></li>
 			</ul>
 			<div id="individualsHeader">
 				<h3>Individuals</h3>

--- a/res/js/signatures.js
+++ b/res/js/signatures.js
@@ -30541,11 +30541,6 @@ let individuals = [
 		"affil": "Individual",
 		"expert": false
 	}, {
-		"name": "Xeovo VPN",
-		"url": "https://github.com/nkvname",
-		"affil": "Individual",
-		"expert": false
-	}, {
 		"name": "Daniel Buck",
 		"url": "https://github.com/Tealk",
 		"affil": "Individual",


### PR DESCRIPTION
Seems like #6464 was added by mistake as individual. Here is the fix. Thanks. 