### PR TITLE
Fix URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,15 +41,24 @@
 				}
 				return 0
 			})
+
+			function urlify(address) {
+				if (!/^(?:f|ht)tps?\:\/\//.test(address)) {
+					address = "http://" + address;
+				}
+				return address;
+			}
+
 			individuals.forEach((individual) => {
 				let li = document.createElement("li")
 				let a = document.createElement("a")
+				a.setAttribute("target", "_blank")
 				let span = document.createElement("span")
 				let br = document.createElement("br")
 				if (individual.expert) {
 					li.classList.add("expert")
 				}
-				a.href = individual.url
+				a.href = urlify(individual.url)
 				a.innerText = individual.name
 				span.innerText = `${individual.affil}`
 				li.appendChild(a)
@@ -69,7 +78,7 @@
 			<h1>An Open Letter Against Apple's Privacy-Invasive Content Scanning Technology</h1>
 			<h2>Security &amp; Privacy Experts, Cryptographers, Researchers, Professors, Legal Experts and Apple Consumers Decry Apple's Planned Move to Undermine User Privacy and End-to-End Encryption</h2>
 			<p>
-				&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
+				&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
 			</p>
 		</div>
 		<div id="letter">
@@ -114,7 +123,7 @@
 				&ldquo;If Apple are successful in introducing this, how long do you think it will be before the same is expected of other providers? Before walled-garden prohibit apps that don't do it? Before it is enshrined in law? How long do you think it will be before the database is expanded to include "terrorist" content"? "harmful-but-legal" content"? state-specific censorship?&rdquo;
 			</blockquote>
 			<p>
-				Dr. Nadim Kobeissi, a researcher in Security &amp; Privacy issues, <a href="https://twitter.com/kaepora/status/1423388549529968645">warned</a>:
+				Dr. Nadim Kobeissi, a researcher in Security &amp; Privacy issues, <a href="https://twitter.com/kaepora/status/1423388549529968645" target="_blank">warned</a>:
 			</p>
 			<blockquote>
 				&ldquo;Apple sells iPhones without FaceTime in Saudi Arabia, because local regulation prohibits encrypted phone calls. That's just one example of many where Apple's bent to local pressure. What happens when local regulations in Saudi Arabia mandate that messages be scanned not for child sexual abuse, but for homosexuality or for offenses against the monarchy?&rdquo;
@@ -157,52 +166,52 @@
 				<h2>Signatures</h2>
 				<h3>Organizations</h3>
 				<p>
-					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
+					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
 				</p>
 			</div>
 			<ul id="organizations">
-				<li><a href="https://www.alphachaincapital.co.uk/">Alphachain Capital</a></li>
-				<li><a href="https://twitter.com/CalypsoHost">Calypso IT Services GmbH</a></li>
-				<li><a href="https://chaos-siegen.de">Chaos Computer Club Siegen e. V.</a></li>
-				<li><a href="https://onestla.tech">Collectif Onestla.tech</a></li>
-				<li><a href="https://collegroup.com">Collé Group, LLC</a></li>
-				<li><a href="https://cryptomator.org/">Cryptomator</a></li>
-				<li><a href="https://www.dotplex.com">dotplex Secure Hosting</a></li>
-				<li><a href="https://freedom.press">Freedom of the Press Foundation</a></li>
-				<li><a href="https://gigahost.uk">Gigahost</a></li>
-				<li><a href="https://digitalhumanrights.blog">Giordano Bruno Foundation</a></li>
-				<li><a href="https://gun.eco">GUN</a></li>
-				<li><a href="https://ivpn.net">IVPN</a></li>
-				<li><a href="https://knowledgeatwork.eu">knowledgeatwork UG</a></li>
-				<li><a href="https://latencyzero.com">Latency: Zero, LLC</a></li>
-				<li><a href="https://macdailynews.com">MacDailyNews</a></li>
-				<li><a href="https://mentorlycon.com">MentorLycon</a></li>
-				<li><a href="https://www.mojeek.com">Mojeek</a></li>
-				<li><a href="https://www.netsite.dk">Netsite A/S</a></li>
-				<li><a href="https://nypl.org">The New York Public Library</a></li>
-				<li><a href="https://nixnet.services">NixNet</a></li>
-				<li><a href="https://nrbtech.io">NRB Tech, Ltd.</a></li>
-				<li><a href="https://paylive.co">PayLive</a></li>
-				<li><a href="https://peergos.org">Peergos</a></li>
-				<li><a href="https://possiblesecurity.com">Possible Security</a></li>
-				<li><a href="https://privacy.foundation">Privacy Foundation</a></li>
-				<li><a href="https://www.route1337.com">Route 1337, LLC</a></li>
-				<li><a href="https://safenetworkforum.org">Safe Network Forum</a></li>
-				<li><a href="https://sig.dev">SIGDEV LLC</a></li>
-				<li><a href="https://small-tech.org">Small Technology Foundation</a></li>
-				<li><a href="https://www.swiftynodes.com">Swifty Nodes IT Solutions</a></li>
-				<li><a href="https://www.sym.bio">SymbioSystems LLC</a></li>
-				<li><a href="https://www.thinkprivacy.ch">ThinkPrivacy</a></li>
-				<li><a href="https://webtorrent.io">WebTorrent</a></li>
-				<li><a href="https://xeovo.com">Xeovo VPN</a></li>
+				<li><a href="https://www.alphachaincapital.co.uk/" target="_blank">Alphachain Capital</a></li>
+				<li><a href="https://twitter.com/CalypsoHost" target="_blank">Calypso IT Services GmbH</a></li>
+				<li><a href="https://chaos-siegen.de" target="_blank">Chaos Computer Club Siegen e. V.</a></li>
+				<li><a href="https://onestla.tech" target="_blank">Collectif Onestla.tech</a></li>
+				<li><a href="https://collegroup.com" target="_blank">Collé Group, LLC</a></li>
+				<li><a href="https://cryptomator.org/" target="_blank">Cryptomator</a></li>
+				<li><a href="https://www.dotplex.com" target="_blank">dotplex Secure Hosting</a></li>
+				<li><a href="https://freedom.press" target="_blank">Freedom of the Press Foundation</a></li>
+				<li><a href="https://gigahost.uk" target="_blank">Gigahost</a></li>
+				<li><a href="https://digitalhumanrights.blog" target="_blank">Giordano Bruno Foundation</a></li>
+				<li><a href="https://gun.eco" target="_blank">GUN</a></li>
+				<li><a href="https://ivpn.net" target="_blank">IVPN</a></li>
+				<li><a href="https://knowledgeatwork.eu" target="_blank">knowledgeatwork UG</a></li>
+				<li><a href="https://latencyzero.com" target="_blank">Latency: Zero, LLC</a></li>
+				<li><a href="https://macdailynews.com" target="_blank">MacDailyNews</a></li>
+				<li><a href="https://mentorlycon.com" target="_blank">MentorLycon</a></li>
+				<li><a href="https://www.mojeek.com" target="_blank">Mojeek</a></li>
+				<li><a href="https://www.netsite.dk" target="_blank">Netsite A/S</a></li>
+				<li><a href="https://nypl.org" target="_blank">The New York Public Library</a></li>
+				<li><a href="https://nixnet.services" target="_blank">NixNet</a></li>
+				<li><a href="https://nrbtech.io" target="_blank">NRB Tech, Ltd.</a></li>
+				<li><a href="https://paylive.co" target="_blank">PayLive</a></li>
+				<li><a href="https://peergos.org" target="_blank">Peergos</a></li>
+				<li><a href="https://possiblesecurity.com" target="_blank">Possible Security</a></li>
+				<li><a href="https://privacy.foundation" target="_blank">Privacy Foundation</a></li>
+				<li><a href="https://www.route1337.com" target="_blank">Route 1337, LLC</a></li>
+				<li><a href="https://safenetworkforum.org" target="_blank">Safe Network Forum</a></li>
+				<li><a href="https://sig.dev" target="_blank">SIGDEV LLC</a></li>
+				<li><a href="https://small-tech.org" target="_blank">Small Technology Foundation</a></li>
+				<li><a href="https://www.swiftynodes.com" target="_blank">Swifty Nodes IT Solutions</a></li>
+				<li><a href="https://www.sym.bio" target="_blank">SymbioSystems LLC</a></li>
+				<li><a href="https://www.thinkprivacy.ch" target="_blank">ThinkPrivacy</a></li>
+				<li><a href="https://webtorrent.io" target="_blank">WebTorrent</a></li>
+				<li><a href="https://xeovo.com" target="_blank">Xeovo VPN</a></li>
 			</ul>
 			<div id="individualsHeader">
 				<h3>Individuals</h3>
 				<p>
-					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
+					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
 				</p>
 				<p>
-					Not all individual signatories may appear below: <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues">some may still be awaiting review</a>.
+					Not all individual signatories may appear below: <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues" target="_blank">some may still be awaiting review</a>.
 				</p>
 			</div>
 			<ol id="individuals">

--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
 			individuals.forEach((individual) => {
 				let li = document.createElement("li")
 				let a = document.createElement("a")
-				a.setAttribute("target", "_blank")
 				let span = document.createElement("span")
 				let br = document.createElement("br")
 				if (individual.expert) {
@@ -78,13 +77,13 @@
 			<h1>An Open Letter Against Apple's Privacy-Invasive Content Scanning Technology</h1>
 			<h2>Security &amp; Privacy Experts, Cryptographers, Researchers, Professors, Legal Experts and Apple Consumers Decry Apple's Planned Move to Undermine User Privacy and End-to-End Encryption</h2>
 			<p>
-				&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
+				&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
 			</p>
 		</div>
 		<div id="letter">
 			<h2>Dear Apple,</h2>
 			<p>
-				On August 5th, 2021, Apple Inc. <a href="https://www.apple.com/child-safety/" target="_blank">announced</a> new technological measures meant to apply across virtually all of its devices under the umbrella of <em>&ldquo;Expanded Protections for Children&rdquo;</em>. While child exploitation is a serious problem, and while efforts to combat it are almost unquestionably well-intentioned, <strong>Apple's proposal introduces a backdoor that threatens to undermine fundamental privacy protections for all users of Apple products.</strong>
+				On August 5th, 2021, Apple Inc. <a href="https://www.apple.com/child-safety/">announced</a> new technological measures meant to apply across virtually all of its devices under the umbrella of <em>&ldquo;Expanded Protections for Children&rdquo;</em>. While child exploitation is a serious problem, and while efforts to combat it are almost unquestionably well-intentioned, <strong>Apple's proposal introduces a backdoor that threatens to undermine fundamental privacy protections for all users of Apple products.</strong>
 			</p>
 			<p>
 				Apple's proposed technology works by continuously monitoring photos saved or shared on the user's iPhone, iPad, or Mac. One system detects if a certain number of objectionable photos is detected in iCloud storage and alerts the authorities. Another notifies a child's parents if iMessage is used to send or receive photos that a machine learning algorithm considers to contain nudity.
@@ -96,40 +95,40 @@
 				Immediately after Apple's announcement, experts around the world sounded the alarm on how Apple's proposed measures could turn every iPhone into a device that is continuously scanning all photos and messages that pass through it in order to report any objectionable content to law enforcement, setting a precedent where our personal devices become a radical new tool for invasive surveillance, with little oversight to prevent eventual abuse and unreasonable expansion of the scope of surveillance.
 			</p>
 			<p>
-				The <a href="https://www.eff.org/deeplinks/2021/08/apples-plan-think-different-about-encryption-opens-backdoor-your-private-life" target="_blank">Electronic Frontier Foundation has said</a> that <strong><em>&ldquo;Apple is opening the door to broader abuses&rdquo;</em></strong>:
+				The <a href="https://www.eff.org/deeplinks/2021/08/apples-plan-think-different-about-encryption-opens-backdoor-your-private-life">Electronic Frontier Foundation has said</a> that <strong><em>&ldquo;Apple is opening the door to broader abuses&rdquo;</em></strong>:
 			</p>
 			<blockquote>
 				&ldquo;It’s impossible to build a client-side scanning system that can only be used for sexually explicit images sent or received by children. As a consequence, even a well-intentioned effort to build such a system will break key promises of the messenger’s encryption itself and open the door to broader abuses [&mldr;] That’s not a slippery slope; that’s a fully built system just waiting for external pressure to make the slightest change.&rdquo;
 			</blockquote>
 			<p>
-				The <a href="https://cdt.org/press/cdt-apples-changes-to-messaging-and-photo-services-threaten-users-security-and-privacy/" target="_blank">Center for Democracy and Technology</a> has said that it is <strong><em>&ldquo;deeply concerned that Apple’s changes in fact create new risks to children and all users, and mark a significant departure from long-held privacy and security protocols&rdquo;</em></strong>:
+				The <a href="https://cdt.org/press/cdt-apples-changes-to-messaging-and-photo-services-threaten-users-security-and-privacy/">Center for Democracy and Technology</a> has said that it is <strong><em>&ldquo;deeply concerned that Apple’s changes in fact create new risks to children and all users, and mark a significant departure from long-held privacy and security protocols&rdquo;</em></strong>:
 			</p>
 			<blockquote>
 				&ldquo;Apple is replacing its industry-standard end-to-end encrypted messaging system with an infrastructure for surveillance and censorship, which will be vulnerable to abuse and scope-creep not only in the U.S., but around the world,&rdquo; says Greg Nojeim, Co-Director of CDT’s Security &amp; Surveillance Project. &ldquo;Apple should abandon these changes and restore its users’ faith in the security and integrity of their data on Apple devices and services.&rdquo;
 			</blockquote>
 			<p>
-				Dr. Carmela Troncoso, a leading research expert in Security &amp; Privacy and professor at EPFL in Lausanne, Switzerland, <a href="https://twitter.com/carmelatroncoso/status/1423554795487518723" target="_blank">has said</a> that while <strong><em>&ldquo;Apple's new detector for child sexual abuse material (CSAM) is promoted under the umbrella of child protection and privacy, it is a firm step towards prevalent surveillance and control&rdquo;</em></strong>.
+				Dr. Carmela Troncoso, a leading research expert in Security &amp; Privacy and professor at EPFL in Lausanne, Switzerland, <a href="https://twitter.com/carmelatroncoso/status/1423554795487518723">has said</a> that while <strong><em>&ldquo;Apple's new detector for child sexual abuse material (CSAM) is promoted under the umbrella of child protection and privacy, it is a firm step towards prevalent surveillance and control&rdquo;</em></strong>.
 			</p>
 			<p>
-				Dr. Matthew D. Green, another leading research expert in Security &amp; Privacy and professor at the Johns Hopkins University in Baltimore, Maryland, <a href="https://twitter.com/matthew_d_green" target="_blank">has said</a> that <strong><em>&ldquo;yesterday we were gradually headed towards a future where less and less of our information had to be under the control and review of anyone but ourselves. For the first time since the 1990s we were taking our privacy back. Today we’re on a different path&rdquo;</em></strong>, <a href="https://www.wired.com/story/apple-csam-detection-icloud-photos-encryption-privacy/" target="_blank">adding</a>:
+				Dr. Matthew D. Green, another leading research expert in Security &amp; Privacy and professor at the Johns Hopkins University in Baltimore, Maryland, <a href="https://twitter.com/matthew_d_green">has said</a> that <strong><em>&ldquo;yesterday we were gradually headed towards a future where less and less of our information had to be under the control and review of anyone but ourselves. For the first time since the 1990s we were taking our privacy back. Today we’re on a different path&rdquo;</em></strong>, <a href="https://www.wired.com/story/apple-csam-detection-icloud-photos-encryption-privacy/">adding</a>:
 			</p>
 			<blockquote>
 				&ldquo;The pressure is going to come from the UK, from the US, from India, from China. I'm terrified about what that's going to look like. Why Apple would want to tell the world, ‘Hey, we've got this tool’?&rdquo;
 			</blockquote>
 			<p>
-				Sarah Jamie Lewis, Executive Director of the <a href="https://openprivacy.ca" target="_blank">Open Privacy Research Society</a>, <a href="https://twitter.com/SarahJamieLewis/status/1423403656733290496" target="_blank">has warned</a> that:
+				Sarah Jamie Lewis, Executive Director of the <a href="https://openprivacy.ca">Open Privacy Research Society</a>, <a href="https://twitter.com/SarahJamieLewis/status/1423403656733290496">has warned</a> that:
 			</p>
 			<blockquote>
 				&ldquo;If Apple are successful in introducing this, how long do you think it will be before the same is expected of other providers? Before walled-garden prohibit apps that don't do it? Before it is enshrined in law? How long do you think it will be before the database is expanded to include "terrorist" content"? "harmful-but-legal" content"? state-specific censorship?&rdquo;
 			</blockquote>
 			<p>
-				Dr. Nadim Kobeissi, a researcher in Security &amp; Privacy issues, <a href="https://twitter.com/kaepora/status/1423388549529968645" target="_blank">warned</a>:
+				Dr. Nadim Kobeissi, a researcher in Security &amp; Privacy issues, <a href="https://twitter.com/kaepora/status/1423388549529968645">warned</a>:
 			</p>
 			<blockquote>
 				&ldquo;Apple sells iPhones without FaceTime in Saudi Arabia, because local regulation prohibits encrypted phone calls. That's just one example of many where Apple's bent to local pressure. What happens when local regulations in Saudi Arabia mandate that messages be scanned not for child sexual abuse, but for homosexuality or for offenses against the monarchy?&rdquo;
 			</blockquote>
 			<p>
-				The Electronic Frontier Foundation's <a href="https://www.eff.org/deeplinks/2021/08/apples-plan-think-different-about-encryption-opens-backdoor-your-private-life" target="_blank">statement</a> on the issue supports the above concern with additional examples on how Apple's proposed technology could lead to global abuse:
+				The Electronic Frontier Foundation's <a href="https://www.eff.org/deeplinks/2021/08/apples-plan-think-different-about-encryption-opens-backdoor-your-private-life">statement</a> on the issue supports the above concern with additional examples on how Apple's proposed technology could lead to global abuse:
 			</p>
 			<blockquote>
 				&ldquo;Take the example of India, where recently passed rules include dangerous requirements for platforms to identify the origins of messages and pre-screen content. New laws in Ethiopia requiring content takedowns of “misinformation” in 24 hours may apply to messaging services. And many other countries—often those with authoritarian governments—have passed similar laws. Apple’s changes would enable such screening, takedown, and reporting in its end-to-end messaging. The abuse cases are easy to imagine: governments that outlaw homosexuality might require the classifier to be trained to restrict apparent LGBTQ+ content, or an authoritarian regime might demand the classifier be able to spot popular satirical images or protest flyers.&rdquo;
@@ -138,13 +137,13 @@
 				Furthermore, the Electronic Frontier Foundation insists that it's already seen this mission creep in action: <strong><em>&ldquo;one of the technologies originally built to scan and hash child sexual abuse imagery has been repurposed to create a database of “terrorist” content that companies can contribute to and access for the purpose of banning such content. The database, managed by the Global Internet Forum to Counter Terrorism (GIFCT), is troublingly without external oversight, despite calls from civil society.&rdquo;</em></strong>
 			</p>
 			<p>
-				Fundamental design flaws in Apple's proposed approach have also been pointed out by experts, who have <a href="https://twitter.com/kaepora/status/1423387147172724741" target="_blank">claimed</a> that <strong><em>&ldquo;Apple can trivially use different media fingerprinting datasets for each user. For one user it could be child abuse, for another it could be a much broader category&rdquo;</em></strong>, thereby enabling selective content tracking for targeted users.
+				Fundamental design flaws in Apple's proposed approach have also been pointed out by experts, who have <a href="https://twitter.com/kaepora/status/1423387147172724741">claimed</a> that <strong><em>&ldquo;Apple can trivially use different media fingerprinting datasets for each user. For one user it could be child abuse, for another it could be a much broader category&rdquo;</em></strong>, thereby enabling selective content tracking for targeted users.
 			</p>
 			<p>
-				The type of technology that Apple is proposing for its child protection measures depends on an expandable infrastructure that can't be monitored or technically limited. Experts have <a href="https://twitter.com/carmelatroncoso/status/1423554811086188548" target="_blank">repeatedly warned</a> that the problem isn't just privacy, but also the lack of accountability, technical barriers to expansion, and lack of analysis or even acknowledgement of the potential for errors and false positives.
+				The type of technology that Apple is proposing for its child protection measures depends on an expandable infrastructure that can't be monitored or technically limited. Experts have <a href="https://twitter.com/carmelatroncoso/status/1423554811086188548">repeatedly warned</a> that the problem isn't just privacy, but also the lack of accountability, technical barriers to expansion, and lack of analysis or even acknowledgement of the potential for errors and false positives.
 			</p>
 			<p>
-				Kendra Albert, a lawyer at the Harvard Law School's Cyberlaw Clinic, <a href="https://twitter.com/KendraSerra/status/1423365222841135114" target="_blank">has warned</a> that <strong><em>&ldquo;these "child protection" features are going to get queer kids kicked out of their homes, beaten, or worse&rdquo;</em></strong>, adding:
+				Kendra Albert, a lawyer at the Harvard Law School's Cyberlaw Clinic, <a href="https://twitter.com/KendraSerra/status/1423365222841135114">has warned</a> that <strong><em>&ldquo;these "child protection" features are going to get queer kids kicked out of their homes, beaten, or worse&rdquo;</em></strong>, adding:
 			</p>
 			<blockquote>
 				&ldquo;I just know (calling it now) that these machine learning algorithms are going to flag transition photos. Good luck texting your friends a picture of you if you have "female presenting nipples."&rdquo;
@@ -166,52 +165,52 @@
 				<h2>Signatures</h2>
 				<h3>Organizations</h3>
 				<p>
-					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
+					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
 				</p>
 			</div>
 			<ul id="organizations">
-				<li><a href="https://www.alphachaincapital.co.uk/" target="_blank">Alphachain Capital</a></li>
-				<li><a href="https://twitter.com/CalypsoHost" target="_blank">Calypso IT Services GmbH</a></li>
-				<li><a href="https://chaos-siegen.de" target="_blank">Chaos Computer Club Siegen e. V.</a></li>
-				<li><a href="https://onestla.tech" target="_blank">Collectif Onestla.tech</a></li>
-				<li><a href="https://collegroup.com" target="_blank">Collé Group, LLC</a></li>
-				<li><a href="https://cryptomator.org/" target="_blank">Cryptomator</a></li>
-				<li><a href="https://www.dotplex.com" target="_blank">dotplex Secure Hosting</a></li>
-				<li><a href="https://freedom.press" target="_blank">Freedom of the Press Foundation</a></li>
-				<li><a href="https://gigahost.uk" target="_blank">Gigahost</a></li>
-				<li><a href="https://digitalhumanrights.blog" target="_blank">Giordano Bruno Foundation</a></li>
-				<li><a href="https://gun.eco" target="_blank">GUN</a></li>
-				<li><a href="https://ivpn.net" target="_blank">IVPN</a></li>
-				<li><a href="https://knowledgeatwork.eu" target="_blank">knowledgeatwork UG</a></li>
-				<li><a href="https://latencyzero.com" target="_blank">Latency: Zero, LLC</a></li>
-				<li><a href="https://macdailynews.com" target="_blank">MacDailyNews</a></li>
-				<li><a href="https://mentorlycon.com" target="_blank">MentorLycon</a></li>
-				<li><a href="https://www.mojeek.com" target="_blank">Mojeek</a></li>
-				<li><a href="https://www.netsite.dk" target="_blank">Netsite A/S</a></li>
-				<li><a href="https://nypl.org" target="_blank">The New York Public Library</a></li>
-				<li><a href="https://nixnet.services" target="_blank">NixNet</a></li>
-				<li><a href="https://nrbtech.io" target="_blank">NRB Tech, Ltd.</a></li>
-				<li><a href="https://paylive.co" target="_blank">PayLive</a></li>
-				<li><a href="https://peergos.org" target="_blank">Peergos</a></li>
-				<li><a href="https://possiblesecurity.com" target="_blank">Possible Security</a></li>
-				<li><a href="https://privacy.foundation" target="_blank">Privacy Foundation</a></li>
-				<li><a href="https://www.route1337.com" target="_blank">Route 1337, LLC</a></li>
-				<li><a href="https://safenetworkforum.org" target="_blank">Safe Network Forum</a></li>
-				<li><a href="https://sig.dev" target="_blank">SIGDEV LLC</a></li>
-				<li><a href="https://small-tech.org" target="_blank">Small Technology Foundation</a></li>
-				<li><a href="https://www.swiftynodes.com" target="_blank">Swifty Nodes IT Solutions</a></li>
-				<li><a href="https://www.sym.bio" target="_blank">SymbioSystems LLC</a></li>
-				<li><a href="https://www.thinkprivacy.ch" target="_blank">ThinkPrivacy</a></li>
-				<li><a href="https://webtorrent.io" target="_blank">WebTorrent</a></li>
-				<li><a href="https://xeovo.com" target="_blank">Xeovo VPN</a></li>
+				<li><a href="https://www.alphachaincapital.co.uk/">Alphachain Capital</a></li>
+				<li><a href="https://twitter.com/CalypsoHost">Calypso IT Services GmbH</a></li>
+				<li><a href="https://chaos-siegen.de">Chaos Computer Club Siegen e. V.</a></li>
+				<li><a href="https://onestla.tech">Collectif Onestla.tech</a></li>
+				<li><a href="https://collegroup.com">Collé Group, LLC</a></li>
+				<li><a href="https://cryptomator.org/">Cryptomator</a></li>
+				<li><a href="https://www.dotplex.com">dotplex Secure Hosting</a></li>
+				<li><a href="https://freedom.press">Freedom of the Press Foundation</a></li>
+				<li><a href="https://gigahost.uk">Gigahost</a></li>
+				<li><a href="https://digitalhumanrights.blog">Giordano Bruno Foundation</a></li>
+				<li><a href="https://gun.eco">GUN</a></li>
+				<li><a href="https://ivpn.net">IVPN</a></li>
+				<li><a href="https://knowledgeatwork.eu">knowledgeatwork UG</a></li>
+				<li><a href="https://latencyzero.com">Latency: Zero, LLC</a></li>
+				<li><a href="https://macdailynews.com">MacDailyNews</a></li>
+				<li><a href="https://mentorlycon.com">MentorLycon</a></li>
+				<li><a href="https://www.mojeek.com">Mojeek</a></li>
+				<li><a href="https://www.netsite.dk">Netsite A/S</a></li>
+				<li><a href="https://nypl.org">The New York Public Library</a></li>
+				<li><a href="https://nixnet.services">NixNet</a></li>
+				<li><a href="https://nrbtech.io">NRB Tech, Ltd.</a></li>
+				<li><a href="https://paylive.co">PayLive</a></li>
+				<li><a href="https://peergos.org">Peergos</a></li>
+				<li><a href="https://possiblesecurity.com">Possible Security</a></li>
+				<li><a href="https://privacy.foundation">Privacy Foundation</a></li>
+				<li><a href="https://www.route1337.com">Route 1337, LLC</a></li>
+				<li><a href="https://safenetworkforum.org">Safe Network Forum</a></li>
+				<li><a href="https://sig.dev">SIGDEV LLC</a></li>
+				<li><a href="https://small-tech.org">Small Technology Foundation</a></li>
+				<li><a href="https://www.swiftynodes.com">Swifty Nodes IT Solutions</a></li>
+				<li><a href="https://www.sym.bio">SymbioSystems LLC</a></li>
+				<li><a href="https://www.thinkprivacy.ch">ThinkPrivacy</a></li>
+				<li><a href="https://webtorrent.io">WebTorrent</a></li>
+				<li><a href="https://xeovo.com">Xeovo VPN</a></li>
 			</ul>
 			<div id="individualsHeader">
 				<h3>Individuals</h3>
 				<p>
-					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here" target="_blank">Sign the letter via GitHub</a>.
+					&rarr; <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues/new?assignees=nadimkobeissi&labels=signature&template=sign-letter.yml&title=%5BSIGN%5D+Your+Name+Here">Sign the letter via GitHub</a>.
 				</p>
 				<p>
-					Not all individual signatories may appear below: <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues" target="_blank">some may still be awaiting review</a>.
+					Not all individual signatories may appear below: <a href="https://github.com/nadimkobeissi/appleprivacyletter/issues">some may still be awaiting review</a>.
 				</p>
 			</div>
 			<ol id="individuals">
@@ -220,7 +219,7 @@
 		</div>
 		<div id="footer">
 			<p>
-				<a target="_blank" href="https://twitter.com/share?text=Read and sign the open letter protesting against Apple's roll-out of new content-scanning technology that threatens to overturn individual privacy on a global scale, and to reverse progress achieved with end-to-end encryption for all.&url=https://appleprivacyletter.com&related=kaepora&dnt=true&show-count=false" class="twitter-share-button">
+				<a href="https://twitter.com/share?text=Read and sign the open letter protesting against Apple's roll-out of new content-scanning technology that threatens to overturn individual privacy on a global scale, and to reverse progress achieved with end-to-end encryption for all.&url=https://appleprivacyletter.com&related=kaepora&dnt=true&show-count=false" class="twitter-share-button">
 					<img src="/res/img/tweet.png"/>
 				</a>
 				<span style="float: right;">Letter written August 6th, 2021.</span>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
 			function urlify(address) {
 				if (!/^(?:f|ht)tps?\:\/\//.test(address)) {
-					address = "http://" + address;
+					address = "https://" + address;
 				}
 				return address;
 			}


### PR DESCRIPTION
1. ~Links changed to `target="_blank"` so visitors can remain reading the page~
2. Some signers might add their URL without `http(s)://`, therefore the links wouldn't work as expected. Added function to check for these addresses and prepend `http://` if missing