### PR TITLE
Changes Dr. Neal Krawetz to be classified as an expert

### DIFF
--- a/res/js/signatures.js
+++ b/res/js/signatures.js
@@ -5842,7 +5842,7 @@ let individuals = [{
 	"name": "Neal Krawetz",
 	"url": "https://github.com/hackerfactor",
 	"affil": "Hacker Factor",
-	"expert": false
+	"expert": true
 }, {
 	"name": "Hendrik S",
 	"url": "https://github.com/hoodie",


### PR DESCRIPTION
Dr. Krawetz holds a PHD in computer science and is known for creating image analysis software.  He has personally dealt with and responsibly disclosed CSAM material as a result of running fotoforensics.com

As a bonus, [his blog post](https://www.hackerfactor.com/blog/index.php?/archives/929-One-Bad-Apple.html) on the subject contains some well reasoned points and insights.